### PR TITLE
No longer limit the last field of id_rsa.pub to be email address.

### DIFF
--- a/ssh-fingerprint.js
+++ b/ssh-fingerprint.js
@@ -1,6 +1,6 @@
 var crypto = require('crypto');
 
-var pubre = /^(ssh-[dr]s[as]\s+)|(\s+.+\@.+)|\n/g;
+var pubre = /^(ssh-[dr]s[as]\s+)|(\s+.+)|\n/g;
 
 module.exports = fingerprint;
 


### PR DESCRIPTION
id_rsa.pub:

```
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDhxh6haTp2u2zk65AMYoz02Kf5cJfMnwNgk1KC99s7yfoZ04Op8lwMUDSW4I7OJaKmqQ8WK/PDID50NpgTR5e8zwjOa4SLCU1wLST7tXPBvVSKvpRfLKKJgEXYcHIPkR4xwsQ0gbHmAl79MNVkmV+8mBCv+CcvR1swnxa6T5hkAvfZ2QyN1iCBJohoru58fFY0vrfKWFVfLDOWoPi/Lpy2lF8PsKH5lp6hFbYApm8v/wxoDtFzBEV7gTd6Om87mZwYIrwfwNuFfTiSDU6wD6Sd4KfllKymKiVtP0ehhX0h4vno/zIiFfZxBnGwzZ11CAqvtIQz7C5A67hpS8aFsQyh jysperm
```

`ssh-keygen -l -f id_rsa.pub`:

```
2048 81:e1:28:58:1a:3c:f8:a6:6c:e2:71:47:81:9b:e2:76  jysperm (RSA)
```

But result of node-ssh-fingerprint is `fd:4c:50:a9:72:fb:e3:b4:47:c5:ad:fd:0d:1c:23:39`.
