### PR TITLE
Compatibility with OpenSSH 6.8 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,19 @@ fingerprint => 64:c4:c5:c9:7e:91:91:db:e3:35:ca:de:be:84:2e:b0
 Usage
 -----
 
-### `fingerprint(pubkey, algorithm = 'md5');`
+### `fingerprint(pubkey, algorithm = 'md5', style = 'hex');`
 
 Parameters
 
 - `pubkey`: A public key string, typically read from `id_rsa.pub`
-- `algorithm`: Hashing algorithm to use, defaults to `md5` (OpenSSH Standard)
+- `algorithm`: Hashing algorithm to use, defaults to `md5` (OpenSSH Standard prior to 6.8)
+- `hex`: Style of hash output, choose from `hex` (OpenSSH 6.7 style) or `base64` (OpenSSH 6.8 and later)
+
+The default value of `style` will change to `base64` when using an algorithm other than `md5` -- this mimics the behaviour of `ssh-keygen` in OpenSSH 6.8 and later.
 
 Returns
 
-- The stringified fingerprint, same as `ssh-keygen -fl id_rsa.pub`
+- The stringified fingerprint, same as `ssh-keygen -E algorithm -fl id_rsa.pub`
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -14,35 +14,53 @@ Example
 ``` js
 var fs = require('fs');
 
-var fingerprint = require('ssh-fingerprint');
+var fp = require('ssh-fingerprint');
 
 var publickey = fs.readFileSync('id_rsa.pub', 'utf-8');
 
-console.log('fingerprint => %s', fingerprint(publickey));
+console.log('fingerprint => %s',
+  fp.calculate(publickey));
+console.log('fingerprint => %s',
+  fp.calculate(publickey, {algorithm: 'sha256'}));
 ```
 
 yields
 
 ```
 fingerprint => 64:c4:c5:c9:7e:91:91:db:e3:35:ca:de:be:84:2e:b0
+fingerprint => SHA256:PKBYeRc7Vm0TFSoc4qzRZa4ArOMVvxztziWf6Rh2LHU
 ```
 
 Usage
 -----
 
-### `fingerprint(pubkey, algorithm = 'md5', style = 'hex');`
+### `fingerprint.calculate(pubkey, options);`
 
 Parameters
 
 - `pubkey`: A public key string, typically read from `id_rsa.pub`
-- `algorithm`: Hashing algorithm to use, defaults to `md5` (OpenSSH Standard prior to 6.8)
-- `hex`: Style of hash output, choose from `hex` (OpenSSH 6.7 style) or `base64` (OpenSSH 6.8 and later)
+- `options`: An object, should contain one or both of the properties:
+  - `algorithm`: The hashing algorithm to use, defaults to `md5` (OpenSSH Standard prior to 6.8)
+  - `style`: Output format of the fingerprint, choose from `hex` (the old style) or `base64`
 
-The default value of `style` will change to `base64` when using an algorithm other than `md5` -- this mimics the behaviour of `ssh-keygen` in OpenSSH 6.8 and later.
+The default value for `style` will change to `base64` when using an algorithm other than `md5` -- this mimics the behaviour of `ssh-keygen` in OpenSSH 6.8 and later.
 
 Returns
 
 - The stringified fingerprint, same as `ssh-keygen -E algorithm -fl id_rsa.pub`
+
+### `fingerprint(pubkey, algorithm = 'md5');`
+
+Compatibility alias for `fingerprint.calculate()`.
+
+Parameters
+
+- `pubkey`: A public key string
+- `algorithm`: A string name of a hashing algorithm to use, same as `options.algorithm` above
+
+Returns
+
+- The stringified fingerprint, as above
 
 License
 -------

--- a/ssh-fingerprint.js
+++ b/ssh-fingerprint.js
@@ -4,22 +4,43 @@ var pubre = /^(ssh-[dr]s[as]\s+)|(\s+.+)|\n/g;
 
 module.exports = fingerprint;
 
-function fingerprint(pub, alg) {
+function fingerprint(pub, alg, style) {
   alg = alg || 'md5'; // OpenSSH Standard
+
+  if (style === undefined)
+    if (alg === 'md5')
+      style = 'hex';
+    else
+      style = 'base64';
 
   var cleanpub = pub.replace(pubre, '');
   var pubbuffer = new Buffer(cleanpub, 'base64');
-  var key = hash(pubbuffer, alg);
+  var key = hash(pubbuffer, alg, style);
 
-  return colons(key);
+  return key;
 }
 
 // hash a string with the given alg
-function hash(s, alg) {
-  return crypto.createHash(alg).update(s).digest('hex');
+function hash(s, alg, style) {
+  var h = crypto.createHash(alg).update(s);
+  if (style === 'hex')
+    return colons(h.digest('hex'));
+  else if (style === 'base64')
+    return sshBase64Format(alg, h);
+  else
+    throw (new Error('Unknown hash style: ' + style));
+}
+
+function sshBase64Format(alg, h) {
+  return alg.toUpperCase() + ':' + base64Strip(h.digest('base64'));
 }
 
 // add colons, 'hello' => 'he:ll:o'
 function colons(s) {
   return s.replace(/(.{2})(?=.)/g, '$1:');
+}
+
+// strip trailing = on base64-encoded payload
+function base64Strip(s) {
+  return s.replace(/=*$/, '');
 }

--- a/ssh-fingerprint.js
+++ b/ssh-fingerprint.js
@@ -2,11 +2,26 @@ var crypto = require('crypto');
 
 var pubre = /^(ssh-[dr]s[as]\s+)|(\s+.+)|\n/g;
 
+/* So you can var f = require('ssh-fingerprint'); f(...) */
 module.exports = fingerprint;
+fingerprint.calculate = calculate;
 
-function fingerprint(pub, alg, style) {
+function fingerprint(pub, alg) {
+  if (typeof (alg) !== 'string')
+    throw (new TypeError('Expected string as second argument, ' +
+      'got a ' + typeof (alg) + ' instead'));
+  return (calculate(pub, {algorithm: alg}));
+}
+
+function calculate(pub, opts) {
+  if (typeof(opts) !== 'object')
+    throw (new TypeError('Expected object as second argument, ' +
+      'got a ' + typeof (opts) + ' instead'));
+
+  var alg = opts.algorithm;
+  var style = opts.style;
+
   alg = alg || 'md5'; // OpenSSH Standard
-
   if (style === undefined)
     if (alg === 'md5')
       style = 'hex';

--- a/test/simple.js
+++ b/test/simple.js
@@ -9,6 +9,7 @@ var PUBLIC_KEY = fs.readFileSync(path.join(__dirname, 'id_rsa.pub'), 'utf-8');
 var known_md5fingerprint = '64:c4:c5:c9:7e:91:91:db:e3:35:ca:de:be:84:2e:b0'; // `ssh-keygen -lf id_rsa.pub`
 var known_sha1fingerprint = 'SHA1:/OHkp4vqKvRyTx/zgUBKWylKvLA'; // `ssh-keygen -E sha1 -lf id_rsa.pub`
 var known_sha256fingerprint = 'SHA256:PKBYeRc7Vm0TFSoc4qzRZa4ArOMVvxztziWf6Rh2LHU'; // `ssh-keygen -E sha256 -lf id_rsa.pub`
+var known_sha1HexFingerprint = 'fc:e1:e4:a7:8b:ea:2a:f4:72:4f:1f:f3:81:40:4a:5b:29:4a:bc:b0';
 
 var md5fingerprint = fingerprint(PUBLIC_KEY, 'md5');
 console.log('md5 => %s', md5fingerprint);
@@ -18,6 +19,20 @@ var sha1fingerprint = fingerprint(PUBLIC_KEY, 'sha1');
 console.log('sha1 => %s', sha1fingerprint);
 assert.strictEqual(sha1fingerprint, known_sha1fingerprint);
 
-var sha256fingerprint = fingerprint(PUBLIC_KEY, 'sha256');
+assert.throws(function () {
+  fingerprint(PUBLIC_KEY, {});
+}, TypeError);
+
+var sha256fingerprint = fingerprint.calculate(PUBLIC_KEY, {algorithm: 'sha256'});
 console.log('sha256 => %s', sha256fingerprint);
 assert.strictEqual(sha256fingerprint, known_sha256fingerprint);
+
+assert.throws(function () {
+  fingerprint(PUBLIC_KEY, 1234);
+}, TypeError);
+assert.throws(function () {
+  fingerprint(PUBLIC_KEY, 'notahashtype');
+});
+
+var sha1HexFingerprint = fingerprint.calculate(PUBLIC_KEY, {algorithm: 'sha1', style: 'hex'});
+assert.strictEqual(sha1HexFingerprint, known_sha1HexFingerprint);

--- a/test/simple.js
+++ b/test/simple.js
@@ -7,7 +7,8 @@ var fingerprint = require('../');
 var PUBLIC_KEY = fs.readFileSync(path.join(__dirname, 'id_rsa.pub'), 'utf-8');
 
 var known_md5fingerprint = '64:c4:c5:c9:7e:91:91:db:e3:35:ca:de:be:84:2e:b0'; // `ssh-keygen -lf id_rsa.pub`
-var known_sha1fingerprint = 'fc:e1:e4:a7:8b:ea:2a:f4:72:4f:1f:f3:81:40:4a:5b:29:4a:bc:b0'; // `awk '{print $2}' id_rsa.pub | tr -d '\n' | base64 -D | openssl sha1`
+var known_sha1fingerprint = 'SHA1:/OHkp4vqKvRyTx/zgUBKWylKvLA'; // `ssh-keygen -E sha1 -lf id_rsa.pub`
+var known_sha256fingerprint = 'SHA256:PKBYeRc7Vm0TFSoc4qzRZa4ArOMVvxztziWf6Rh2LHU'; // `ssh-keygen -E sha256 -lf id_rsa.pub`
 
 var md5fingerprint = fingerprint(PUBLIC_KEY, 'md5');
 console.log('md5 => %s', md5fingerprint);
@@ -16,3 +17,7 @@ assert.strictEqual(md5fingerprint, known_md5fingerprint);
 var sha1fingerprint = fingerprint(PUBLIC_KEY, 'sha1');
 console.log('sha1 => %s', sha1fingerprint);
 assert.strictEqual(sha1fingerprint, known_sha1fingerprint);
+
+var sha256fingerprint = fingerprint(PUBLIC_KEY, 'sha256');
+console.log('sha256 => %s', sha256fingerprint);
+assert.strictEqual(sha256fingerprint, known_sha256fingerprint);


### PR DESCRIPTION
This patch adds compatibility with the new default fingerprint format found in OpenSSH 6.8 and later, notably without breaking existing apps that expect the plain MD5 hex format to be the default.

In OpenSSH 6.8 (already in a lot of Linux distros, will be in OSX 10.11 next month), fingerprints now look like `SHA256:PKBYeRc7Vm0TFSoc4qzRZa4ArOMVvxztziWf6Rh2LHU` by default -- an algorithm followed by a colon, followed by the base64 of the hash. You can still get the old MD5 format back by using the `-E md5` option to `ssh-keygen`, but it is now prefixed with `MD5:`.

This patch doesn't add the `MD5:` prefix if you ask for an MD5 hash, to avoid breaking existing apps that aren't expecting this. It does, however, add the algorithm prefix for newer hashes in the base64 style. It also makes the base64 style the default for all hash algorithms that are not MD5.

I've updated the test file and README for this, too. Let me know what you think.
